### PR TITLE
fix: Removing the lambda_handler terms 

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -47,7 +47,7 @@ aws-lambda-s3-copy-zips:latest
 
 ```
     - name: Copy files across S3 buckets
-      uses: GeorgeDavis-Ibexlabs/aws-lambda-s3-copy-zips@v0.0.1
+      uses: GeorgeDavis-Ibexlabs/aws-lambda-s3-copy-zips@v0.0.5
 ```
 Refer to [Copy files across S3 buckets using GitHub Actions](https://github.com/marketplace/actions/aws-lambda-s3-copy-zips)
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ aws-lambda-s3-copy-zips:latest
 
 ```
     - name: Copy files across S3 buckets
-      uses: GeorgeDavis-Ibexlabs/aws-lambda-s3-copy-zips@v0.0.1
+      uses: GeorgeDavis-Ibexlabs/aws-lambda-s3-copy-zips@v0.0.5
 ```
 Refer to [Copy files across S3 buckets using GitHub Actions](https://github.com/marketplace/actions/aws-lambda-s3-copy-zips)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 boto3==1.33.12
 botocore==1.33.12
-cfnresponse==1.1.5


### PR DESCRIPTION
Target runtime is Docker or shell, not AWS Lambda. Running `lambda_handler`, `event` or `context` have no relevance here.